### PR TITLE
Patch video update in FCEUX_Update

### DIFF
--- a/src/drivers/sdl/sdl.cpp
+++ b/src/drivers/sdl/sdl.cpp
@@ -166,10 +166,12 @@ FCEUD_Update(uint8 *XBuf,
 
 		//if(uflow) puts("Underflow");
 		tmpcan = GetWriteSound();
+
+    if(XBuf && (inited&4) && !(NoWaiting & 2))
+      BlitScreen(XBuf);
+
 		// don't underflow when scaling fps
 		if((tmpcan < Count*9/10) && !uflow) {
-			if(XBuf && (inited&4) && !(NoWaiting & 2))
-				BlitScreen(XBuf);
 			Buffer+=can;
 			Count-=can;
 			if(Count) {


### PR DESCRIPTION
In the original implementation of `FCEUX_Update` video and audio updates are integrated, which could lead to a possible defect that audio streaming blocks video streaming. It will try to fill up the sound buffer before writing into the video buffer. Thus if the sound buffer is consumed at a faster rate than receiving, or some sync error happens where sound buffer is full and video is going to output but `XBuf` is null, video is not going to be written into, leading to a black screen.

Moving `BlitScreen` out of audio update could help ease this situation. But this is a temporary patch which may still lead to further bugs since video update is not separated from audio update.